### PR TITLE
Run helptext at end-of-init

### DIFF
--- a/purses/controller.py
+++ b/purses/controller.py
@@ -35,6 +35,8 @@ class Controller(object):
             'kLFT5': self.view.panleft,
         }
 
+        helptext()
+
         def __insert(model, i):
             return lambda: model.insert(i, self.view.coords)
 


### PR DESCRIPTION
Running helptext forces a redraw, so everything is drawn immediately.
Additionally, it's useful for new users to get a quick overview on how
purses is operated.

This fixes the annoying behaviour of having to press a movement key (or similar) in order to get something drawn on startup.